### PR TITLE
implement route for users to delete gcal

### DIFF
--- a/backend/src/calendar/gcal.route.ts
+++ b/backend/src/calendar/gcal.route.ts
@@ -11,5 +11,6 @@ router.post(
   authMiddleware,
   gCalController.addCourseToCalendar
 );
+router.delete("/", authMiddleware, gCalController.clearCalendarEvents);
 
 export default router;

--- a/backend/src/types/requests.ts
+++ b/backend/src/types/requests.ts
@@ -67,4 +67,5 @@ export interface SearchRequestHandlers {
 export interface CalendarRequestHandlers {
   addCourseToCalendar: RequestHandler<{ courseId: string }>;
   getCalendarLink: RequestHandler;
+  clearCalendarEvents: RequestHandler;
 }


### PR DESCRIPTION
This PR adds a new API endpoint that allows users to clear all events from their Google Calendar. This feature provides users with the ability to remove all course-related events from their calendar in bulk. Events are processed in batches of 10 (with a 1-second delay for each batch) to avoid overwhelming the Google Calendar API.